### PR TITLE
Support later Python versions

### DIFF
--- a/.github/workflows/gatherer-tests.yml
+++ b/.github/workflows/gatherer-tests.yml
@@ -48,3 +48,4 @@ jobs:
       matrix:
         python:
         - '3.8.18'
+        - '3.12.3'

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ depending on the situation that they are used in:
 ## Installation
 
 The data gathering scripts and modules require Python version 3.8 and higher. 
-Version 0.0.3 is the last version to support Python 3.6 and the old quality 
-reporting source.
+Version 0.0.3 is the last version to support Python 3.6, 3.7 and the old 
+quality reporting source.
 
 The scripts have been tested on MacOS 10.14+, Ubuntu 16.04+, CentOS 7.3+ as 
 well as on some Windows versions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 [mypy]
 mypy_path = typeshed
-[mypy-bigboat]
-ignore_missing_imports = True
 [mypy-Pyro4]
 ignore_missing_imports = True
 [mypy-etcd3]

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,11 @@ build automation servers (Jenkins) and reservation systems (Topdesk).''',
               'Topic :: System :: Monitoring',
               'License :: OSI Approved :: Apache Software License',
               'Programming Language :: Python :: 3',
-              'Programming Language :: Python :: 3.8'
+              'Programming Language :: Python :: 3.8',
+              'Programming Language :: Python :: 3.9',
+              'Programming Language :: Python :: 3.10',
+              'Programming Language :: Python :: 3.11',
+              'Programming Language :: Python :: 3.12',
           ],
           keywords='gros software development process data gathering')
 


### PR DESCRIPTION
- Run GitHub Actions test on latest Python 3.12 as well as 3.8
- Mention that Python 3.7 support was also dropped
- Stop marking bigboat as potentially having missing modules for typing