### PR TITLE
Handle request exceptions in Jenkins API

### DIFF
--- a/gatherer/domain/source/jenkins.py
+++ b/gatherer/domain/source/jenkins.py
@@ -20,7 +20,6 @@ limitations under the License.
 
 from typing import Hashable, Optional
 from urllib.parse import urlsplit
-from requests.exceptions import ConnectionError as ConnectError, HTTPError, Timeout
 from ...config import Configuration
 from ...jenkins import Jenkins as JenkinsAPI
 from .types import Source, Source_Types, Project
@@ -54,7 +53,7 @@ class Jenkins(Source):
         try:
             self.jenkins_api.timeout = 3
             return self.jenkins_api.version
-        except (RuntimeError, ConnectError, HTTPError, Timeout):
+        except RuntimeError:
             return ''
         finally:
             if self._jenkins_api is not None:


### PR DESCRIPTION
- Instead of passing connection/HTTP errors through to the caller, catch them and raise an exception (with the original exception as source) if this is proper to do. This is more in line with other API wrappers.
- For the crumb token request, do not raise an exception. Instead try to continue with the session without a crumb token. Request a crumb again if the session is used again and it was not a "not found" response.
- Update tests for exception handling and add test for last branch build